### PR TITLE
Add pandas-based trends script and ignore generated images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Generated trend images
+loc_trend.png
+cost_trend.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS instructions
+
+All changes in this repository should ensure that programs rely only on standard Python libraries unless otherwise specified. When adding data visualizations, prefer simple solutions that do not require external dependencies. When running tests or scripts, note if commands fail due to missing packages or network restrictions.
+
+The visualization script `generate_trends.py` may use pandas, matplotlib, and scikit-learn.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Repometrics analyzes Git repositories to measure how much code is written during
 2. For each repository:
    - Identifies the first commit timestamp
    - Finds the last commit within 24 hours of that first commit
-   - Extracts a clean copy of the codebase at that point in time 
+   - Extracts a clean copy of the codebase at that point in time
    - Runs SLOCCount to analyze lines of code and estimated development cost
 
 The results are compiled into a CSV file with each row containing:
@@ -17,7 +17,7 @@ The results are compiled into a CSV file with each row containing:
 - First commit date
 - First commit hash
 - Last commit hash within the first 24 hours
-- Total lines of code 
+- Total lines of code
 - Estimated development cost (using SLOCCount's COCOMO model)
 
 ## Requirements
@@ -51,3 +51,25 @@ imported-project            # Contains pre-existing code
 ```
 
 If no `skiplist.txt` file is found, a default skiplist containing known problematic repositories is used.
+
+## Results
+
+After generating `first_day_analysis.csv`, you can visualize the trends using `generate_trends.py`.
+This script relies on external packages, so install them first:
+
+```
+pip install pandas matplotlib scikit-learn
+```
+
+Then run:
+
+```
+python generate_trends.py
+```
+
+The script generates two images in the repository root:
+
+- `loc_trend.png` – first day lines-of-code over time
+- `cost_trend.png` – estimated first day cost over time
+
+The images are not committed to version control but will appear locally after running the script.

--- a/generate_trends.py
+++ b/generate_trends.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+from sklearn.linear_model import LinearRegression
+import numpy as np
+
+
+def main():
+    df = pd.read_csv('first_day_analysis.csv', parse_dates=['date'])
+    df.sort_values('date', inplace=True)
+
+    dates = df['date']
+    x = np.arange(len(df)).reshape(-1, 1)
+
+    # Plot lines of code
+    plt.figure(figsize=(10, 4))
+    plt.plot(dates, df['total_lines'], 'o-', label='Lines of Code')
+    if len(df) >= 2:
+        model = LinearRegression()
+        model.fit(x, df['total_lines'])
+        trend = model.predict(x)
+        plt.plot(dates, trend, '--', label='Trend')
+    plt.xlabel('Date')
+    plt.ylabel('Total Lines')
+    plt.title('First Day LOC Trend')
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig('loc_trend.png')
+
+    # Plot cost
+    plt.figure(figsize=(10, 4))
+    plt.plot(dates, df['cost_estimate'], 'o-', label='Cost Estimate')
+    if len(df) >= 2:
+        model = LinearRegression()
+        model.fit(x, df['cost_estimate'])
+        trend = model.predict(x)
+        plt.plot(dates, trend, '--', label='Trend')
+    plt.xlabel('Date')
+    plt.ylabel('Cost Estimate')
+    plt.title('First Day Cost Trend')
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig('cost_trend.png')
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
## Summary
- allow `generate_trends.py` to depend on `pandas`, `matplotlib`, and `scikit-learn`
- rewrite the script using those libraries
- document the new dependencies and note that generated images aren't stored
- ignore generated trend PNGs and remove any from version control

## Testing
- ❌ `python3 generate_trends.py` *(failed to run: No module named 'pandas')*
