### PR TITLE
Add output option for analysis CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Results are written to `first_day_analysis.csv` in the current directory. Use `-
 uv run firstday.py --directory /path/to/repos
 ```
 
+You can also change where the CSV file is written with `-o`:
+
+```
+uv run firstday.py -d /path/to/repos -o /tmp/output.csv
+```
+
 ### Repository Skiplist
 
 You can exclude specific repositories from the analysis by creating a `skiplist.txt` file in the same directory as the script. This is useful for repositories that have large initial imports that would skew the results.

--- a/firstday.py
+++ b/firstday.py
@@ -434,9 +434,16 @@ def main(argv=None):
         default="~/devel",
         help="Directory containing repositories (default: ~/devel)",
     )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="first_day_analysis.csv",
+        help="Path for the output CSV file (default: first_day_analysis.csv)",
+    )
     args = parser.parse_args(argv)
 
     devel_dir = args.directory
+    output_csv = Path(args.output)
     
     # Configuration
     skiplist_path = Path.cwd() / 'skiplist.txt'
@@ -492,7 +499,7 @@ def main(argv=None):
         
         # Write results to CSV
         if results:
-            csv_path = Path.cwd() / 'first_day_analysis.csv'
+            csv_path = output_csv if output_csv.is_absolute() else Path.cwd() / output_csv
             with open(csv_path, 'w', newline='') as csvfile:
                 fieldnames = ['repo', 'date', 'first_commit', 'analysis_commit', 'total_lines', 'cost_estimate']
                 writer = csv.DictWriter(csvfile, fieldnames=fieldnames)


### PR DESCRIPTION
## Summary
- add a `-o/--output` CLI option to `firstday.py`
- document the new option in the README

## Testing
- `python -m py_compile firstday.py`
- `python firstday.py -h`