### PR TITLE
Add scripts for commit logging and daily timesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,26 @@ uv run monthly_top_repo.py --plot
 ```
 
 The plot is saved as `loc_vs_cost.png` in the repository root.
+
+### Logging Recent Commits
+
+To gather recent commits from multiple repositories into a single SQLite database run `commit_logger.py`.
+The script walks each directory you provide (default `~/devel`) looking for Git repositories and records
+commits from the last two weeks:
+
+```bash
+uv run commit_logger.py ~/devel ~/Documents/devel --db timesheet.sqlite
+```
+
+Each entry stores the repository path, commit timestamp and the commit message. The database can be
+copied between machines and the script can be run again to append new commits.
+
+### Daily Timesheet
+
+After collecting commits you can print a day-by-day log using `daily_timesheet.py`:
+
+```bash
+uv run daily_timesheet.py --db timesheet.sqlite
+```
+
+This groups commits by day and shows the time, repository and commit message for each entry.

--- a/commit_logger.py
+++ b/commit_logger.py
@@ -1,0 +1,72 @@
+import os
+import subprocess
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+import argparse
+
+
+def find_git_repos(base_dir: Path):
+    """Yield all git repositories under base_dir."""
+    for root, dirs, files in os.walk(base_dir):
+        if '.git' in dirs:
+            yield Path(root)
+            dirs[:] = []  # don't recurse into subdirs of a repo
+
+
+def collect_commits(repo: Path, since: datetime):
+    """Return a list of (hash, timestamp, message) from repo since given time."""
+    fmt = '%H\x1f%cI\x1f%s\x1e'
+    cmd = ['git', 'log', '--since', since.isoformat(), f'--format={fmt}']
+    result = subprocess.run(cmd, cwd=repo, capture_output=True, text=True)
+    if result.returncode != 0:
+        return []
+    data = result.stdout.strip('\x1e')
+    commits = []
+    if not data:
+        return commits
+    for record in data.split('\x1e'):
+        parts = record.split('\x1f')
+        if len(parts) != 3:
+            continue
+        h, ts, msg = parts
+        commits.append((h, ts, msg))
+    return commits
+
+
+def ensure_db(db_path: Path):
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        'CREATE TABLE IF NOT EXISTS commits (repo TEXT, hash TEXT, timestamp TEXT, message TEXT, '
+        'PRIMARY KEY (repo, hash))'
+    )
+    return conn
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Collect recent git commits into SQLite DB.')
+    parser.add_argument('directories', nargs='*', default=['~/devel'], help='Directories to scan')
+    parser.add_argument('--db', default='git_commits.sqlite', help='SQLite database file')
+    parser.add_argument('--days', type=int, default=14, help='How many days back to scan')
+    args = parser.parse_args()
+
+    since = datetime.now() - timedelta(days=args.days)
+    db_path = Path(args.db)
+    conn = ensure_db(db_path)
+
+    for directory in args.directories:
+        base = Path(directory).expanduser()
+        for repo in find_git_repos(base):
+            commits = collect_commits(repo, since)
+            if not commits:
+                continue
+            with conn:
+                conn.executemany(
+                    'INSERT OR IGNORE INTO commits (repo, hash, timestamp, message) VALUES (?, ?, ?, ?)',
+                    ((str(repo), h, ts, msg) for h, ts, msg in commits)
+                )
+            print(f'Logged {len(commits)} commits from {repo}')
+
+
+if __name__ == '__main__':
+    main()

--- a/daily_timesheet.py
+++ b/daily_timesheet.py
@@ -1,0 +1,42 @@
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+import argparse
+
+
+def load_commits(db_path: Path):
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute('SELECT repo, timestamp, message FROM commits ORDER BY timestamp')
+    for repo, ts, msg in cursor:
+        yield repo, ts, msg
+    conn.close()
+
+
+def group_by_day(commits):
+    day_map = {}
+    for repo, ts, msg in commits:
+        day = ts.split('T')[0]
+        day_map.setdefault(day, []).append((ts, repo, msg))
+    return day_map
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Print timesheet from commit log DB.')
+    parser.add_argument('--db', default='git_commits.sqlite', help='Database file')
+    args = parser.parse_args()
+
+    commits = list(load_commits(Path(args.db)))
+    if not commits:
+        print('No commits found.')
+        return
+    days = group_by_day(commits)
+    for day in sorted(days):
+        print(day)
+        for ts, repo, msg in sorted(days[day]):
+            time = ts.split('T')[1][:8]
+            print(f'  {time} {repo} - {msg}')
+        print()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `commit_logger.py` to collect recent commits into SQLite
- add `daily_timesheet.py` to summarize commits by day
- document how to use the new scripts in `README.md`

## Testing
- `python -m py_compile commit_logger.py daily_timesheet.py`
- `uv run commit_logger.py /tmp --db test.sqlite --days 1`
- `sqlite3 test.sqlite "SELECT repo, timestamp, message FROM commits;"`
- `uv run daily_timesheet.py --db test.sqlite`

------
https://chatgpt.com/codex/tasks/task_e_683ee3a09cf48325af81ccd70c834fad