### PR TITLE
Improve repo identification in commit logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ commits from the last two weeks:
 uv run commit_logger.py ~/devel ~/Documents/devel --db timesheet.sqlite
 ```
 
-Each entry stores the repository path, commit timestamp and the commit message. The database can be
+Each entry stores the repository's GitHub path (e.g. `owner/repo`), the commit timestamp and the commit message. The database can be
 copied between machines and the script can be run again to append new commits.
 
 ### Daily Timesheet


### PR DESCRIPTION
## Summary
- normalize repo names to GitHub remote path
- update README to describe new behavior

## Testing
- `uv run commit_logger.py . --days 1 --db test.sqlite`
- `uv run commit_logger.py /tmp/test_repo --days 1000 --db test.sqlite`

------
https://chatgpt.com/codex/tasks/task_e_683ee95114688325a070b78fe930130a